### PR TITLE
feat: Allow users to update their name

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = process.env.JWT_SECRET || "dev-secret-change-me";
+
+export interface AuthenticatedRequest extends Request {
+  user?: { id: string };
+}
+
+export const authenticateToken = (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  const authHeader = req.headers["authorization"];
+  const token = authHeader && authHeader.split(" ")[1];
+
+  if (token == null) {
+    return res.sendStatus(401);
+  }
+
+  jwt.verify(token, JWT_SECRET, (err: any, user: any) => {
+    if (err) {
+      return res.sendStatus(403);
+    }
+    req.user = { id: user.sub };
+    next();
+  });
+};


### PR DESCRIPTION
This commit introduces the functionality for users to update their name from the settings page.

- Adds a new `PUT /api/auth/me` endpoint to the backend to handle the name update.
- The new endpoint is protected by a JWT authentication middleware.
- The frontend settings page now sends the updated name to the new endpoint.
- The user's name is updated in the local state and `localStorage` upon a successful update.
- The email and user ID fields on the settings page have been made read-only.